### PR TITLE
#51 Inventory SOP-adjacent docs

### DIFF
--- a/inventory_sop_docs.md
+++ b/inventory_sop_docs.md
@@ -1,0 +1,29 @@
+# SOP‑adjacent Documentation Inventory
+
+## Runbook / Operational Guides
+- `RUNBOOK.md`
+- `HEARTBEAT.md`
+- `USER_GUIDE.md`
+- `DAILY_BRIEF_TEMPLATE.md`
+- `STANDUP.md`
+- `WEEKLY_REVIEW_CHECKLIST.md`
+
+## Policy / Procedure Documents
+- `AGENTS.md`
+- `BLOCKER_PROTOCOL.md`
+- `GMAIL_SETUP.md`
+- `TOOLS.md`
+- `SOUL.md`
+- `IDENTITY.md`
+
+## Task / Backlog Files
+- `TASK.md`
+- `memory/*.md` (daily logs)
+- `real-estate-assistant/TASK.md`
+- `repo/TASK.md`
+
+## Operational Notes / Misc
+- `HEARTBEAT.md` (lightweight checklist)
+- `README.md`
+- `MEMORY.md`
+- `AGENTS.md` (also contains SOP guidance)


### PR DESCRIPTION
Adds inventory_sop_docs.md listing all SOP-related documentation files as required by issue #51. This fulfills the acceptance criteria of providing a grouped list of policy, runbook, task backlog, and operational note files.